### PR TITLE
[Fix] undefined index EuLoginUser group

### DIFF
--- a/src/Security/Core/User/EuLoginUser.php
+++ b/src/Security/Core/User/EuLoginUser.php
@@ -143,7 +143,7 @@ final class EuLoginUser implements EuLoginUserInterface
      */
     public function getGroups(): array
     {
-        return $this->user->getAttribute('groups', ['group' => []])['group'];
+        return $this->user->getAttribute('group', ['group' => []])['group'];
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue that throws a notice during login via de EU login portal.
An index `groups` is fetched from a received user, but this does not exists, and should be `group` instead.

This notice prevents a good login flow in a more strictly configured PHP environment.

# Screenshot
![eu_login_undefined_index](https://user-images.githubusercontent.com/555558/91533091-99a91e00-e90f-11ea-96e1-e0cbc19ad1e3.png)