### PR TITLE
fix: add missing arg to trigger_deprecation call

### DIFF
--- a/src/Security/Core/User/EuLoginUser.php
+++ b/src/Security/Core/User/EuLoginUser.php
@@ -344,6 +344,7 @@ final class EuLoginUser implements EuLoginUserInterface
             'ecphp/eu-login-bundle',
             '2.2.3',
             'The method "%s::getUser()" is deprecated, use %s::getUsername() instead.',
+            EuLoginUser::class,
             EuLoginUser::class
         );
 


### PR DESCRIPTION
Fix deprecation notice logic that prevents version 1.3.6 to work as expected (problem introduced with 2.2.3 release, it seems)
This PR

* [x] fixes deprecation notice in getUser()
