### PR TITLE
fix: add missing argument to trigger_deprecation call

### DIFF
--- a/src/Security/Core/User/EuLoginUser.php
+++ b/src/Security/Core/User/EuLoginUser.php
@@ -280,6 +280,7 @@ final class EuLoginUser implements EuLoginUserInterface
             'ecphp/eu-login-bundle',
             '2.3.8',
             'The method "%s::getUsername()" is deprecated, use %s::getUserIdentifier() instead.',
+            EuLoginUser::class,
             EuLoginUser::class
         );
 


### PR DESCRIPTION
In branch 2.4, this breaks any remaining use of getUsername()
